### PR TITLE
Added option to write the value to system properties

### DIFF
--- a/src/main/java/org/commonjava/maven/plugins/execroot/AbstractDirectoryGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/AbstractDirectoryGoal.java
@@ -59,6 +59,11 @@ public abstract class AbstractDirectoryGoal
      */
     protected boolean quiet;
 
+    /**
+     * @parameter default-value="false"
+     */
+    protected boolean systemProperty;
+
     protected Map<String, Object> context;
 
     protected AbstractDirectoryGoal()
@@ -91,6 +96,13 @@ public abstract class AbstractDirectoryGoal
         }
 
         currentProject.getProperties().setProperty( property, execRoot.getAbsolutePath() );
+
+        if (systemProperty) {
+            String existingValue = System.getProperty(property);
+            if (existingValue == null) {
+                System.setProperty(property, execRoot.getAbsolutePath());
+            }
+        }
 
         if ( getLog().isDebugEnabled() )
         {


### PR DESCRIPTION
Adds the option to write the resulting value to the system properties. That way it is possible to run the plugin in initialize phase and add a property to "set the default value" which will be overridden by the system property to prevent errors of "non existing properties" to show up.
