### PR TITLE
mark plugin goals thread safe.

### DIFF
--- a/src/main/java/org/commonjava/maven/plugins/execroot/DirectoryOfGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/DirectoryOfGoal.java
@@ -30,8 +30,6 @@ import java.util.Stack;
  * @requiresProject true 
  * @phase initialize
  * @threadSafe true
- * 
- * Find the topmost directory in this Maven execution, and set it as a property.
  */
 public class DirectoryOfGoal
     extends AbstractDirectoryGoal

--- a/src/main/java/org/commonjava/maven/plugins/execroot/ExecutionRootGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/ExecutionRootGoal.java
@@ -26,8 +26,6 @@ import java.io.File;
  * @requiresProject true 
  * @phase initialize
  * @threadSafe true
- * 
- * Find the topmost directory in this Maven execution, and set it as a property.
  */
 public class ExecutionRootGoal
     extends AbstractDirectoryGoal

--- a/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
@@ -34,8 +34,6 @@ import java.util.Stack;
  * @requiresProject true
  * @phase initialize
  * @threadSafe true
- *
- * Find the topmost directory in this Maven execution, and set it as a property.
  */
 public class HighestBasedirGoal
     extends AbstractDirectoryGoal


### PR DESCRIPTION
Previously it wasn't marked because value for @threadSafe tag was
'true\n\nFind the topmost directory in this Maven execution, and set it as a property.'