### PR TITLE
Fixing maven > 3.8.x issues with highest-basedir

### DIFF
--- a/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
@@ -118,6 +118,8 @@ public class HighestBasedirGoal
             }
             if ( !nextPath.startsWith( dirPath ) )
             {
+                getLog().error("Candidate 1: " + dirPath);
+                getLog().error("Candidate 2: " + nextPath);
                 throw new MojoExecutionException( "Cannot find a single highest directory for this project set. "
                     + "First two candidates directories don't share a common root." );
             }

--- a/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
+++ b/src/main/java/org/commonjava/maven/plugins/execroot/HighestBasedirGoal.java
@@ -73,11 +73,14 @@ public class HighestBasedirGoal
         final Stack<MavenProject> toCheck = new Stack<MavenProject>();
         toCheck.addAll( projects );
 
+        // exclude projects loaded directly from the local repository (super-pom's etc)
+        String localRepoBaseDir = session.getLocalRepository().getBasedir();
+
         final List<File> files = new ArrayList<File>();
         while ( !toCheck.isEmpty() )
         {
             final MavenProject p = toCheck.pop();
-            if ( p.getBasedir() == null )
+            if ( (p.getBasedir() == null || (p.getBasedir().toString().startsWith(localRepoBaseDir))) )
             {
                 // we've hit a parent that was resolved. Don't bother going higher up the hierarchy.
                 continue;


### PR DESCRIPTION
This is a fix for #16:

The check `p.getBasedir() == null` no longer works, the basedir is set even for projects in the local repository. I've fixed this by using the local repository basedir to detect the parent to stop at. 

I've also added some additional logging to help debug issues.