### PR TITLE
Changes needed to remove Maven warnings when building using Maven 3.9.x

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-T1C
+--fail-fast
+--also-make-dependents

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <!--
   Copyright 2011 Red Hat, Inc.
-  
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-  
+
   <groupId>org.commonjava.maven.plugins</groupId>
   <artifactId>directory-maven-plugin</artifactId>
   <version>1.1-SNAPSHOT</version>
@@ -29,8 +29,8 @@
 
   <name>Directory Maven Plugin</name>
   <description>
-    Provides goals to discover various paths based on the projects currently building. For example, 
-    directory of the execution root project, directory of a given project (based on groupId/artifactId), 
+    Provides goals to discover various paths based on the projects currently building. For example,
+    directory of the execution root project, directory of a given project (based on groupId/artifactId),
     and highest project basedir that hasn't been resolved from the repository.
   </description>
 
@@ -39,26 +39,22 @@
   </properties>
 
   <scm>
-    <connection>scm:git:http://github.com/jdcasey/directory-maven-plugin.git</connection>
+    <connection>scm:git:https://github.com/jdcasey/directory-maven-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jdcasey/directory-maven-plugin.git</developerConnection>
-    <url>http://github.com/jdcasey/directory-maven-plugin</url>
+    <url>https://github.com/jdcasey/directory-maven-plugin</url>
   </scm>
-  
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven</artifactId>
-        <version>3.8.1</version>
+        <version>3.9.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>
-  
-  <prerequisites>
-    <maven>[3.0,]</maven>
-  </prerequisites>
 
   <dependencies>
     <dependency>
@@ -70,47 +66,104 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <version>3.9.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.8.1</version>
+      <version>3.9.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.8.1</version>
+      <version>3.9.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.9.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.3.0</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <fail>true</fail>
+            <failFast>true</failFast>
+            <ignoreCache>false</ignoreCache>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.sonatype.ossindex.maven</groupId>
+              <artifactId>ossindex-maven-enforcer-rules</artifactId>
+              <version>3.2.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>extra-enforcer-rules</artifactId>
+              <version>1.6.2</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>[3.9,)</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+          <configuration>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>2.9</version>
+          <version>3.9.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.0</version>
           <configuration>
             <detectOfflineLinks>false</detectOfflineLinks>
 
-            <additionalparam>-Xdoclint:none</additionalparam>
             <additionalOptions>-Xdoclint:none</additionalOptions>
             <additionalJOption>-Xdoclint:none</additionalJOption>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Changes needed to remove Maven warnings when building using Maven 3.9.x